### PR TITLE
Fixed compilation with GHC 8.4.3.

### DIFF
--- a/cook.cabal
+++ b/cook.cabal
@@ -8,6 +8,10 @@ homepage:           https://github.com/mietek/cook
 extra-source-files: README.md
 synopsis:           The λ-calculus in Haskell in four different ways
 description:        A runnable version of Augustsson’s paper describing how to implement the λ-calculus in Haskell in four different ways.
+tested-with:   GHC == 8.4.3
+               GHC == 8.2.2
+               GHC == 8.0.2
+               GHC == 7.10.3
 
 executable cook
   hs-source-dirs:     src

--- a/src/Lambda.hs
+++ b/src/Lambda.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- 2.1 Lambda
 -- The Lambda module implements a simple abstract syntax for the λ-calculus together
 -- with a parser and a printer for it.  It also exports a simple type of identifiers
@@ -9,6 +11,10 @@ import Data.List (span, union, (\\))
 import Data.Char (isAlphaNum)
 import Text.PrettyPrint.HughesPJ (Doc, renderStyle, style, text, (<>), (<+>), parens)
 import Text.ParserCombinators.ReadP
+
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 -- The LC type of λ-terms is parametrised over the type of the variables.  It has
 -- constructors for variables, λ-abstraction, and application.


### PR DESCRIPTION
@mietek, thank you for packing Augustsson’s paper.

This PR fix the following error when building with GHC 8.4.3:

```haskell
src/Lambda.hs:110:68: error:
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Prelude.<>’,
                             imported from ‘Prelude’ at src/Lambda.hs:6:8-13
                             (and originally defined in ‘GHC.Base’)
                          or ‘Text.PrettyPrint.HughesPJ.<>’,
                             imported from ‘Text.PrettyPrint.HughesPJ’ at src/Lambda.hs:10:66-69
    |
110 | ppLC p (Lam v e) = pparens (p > 0) $ text ("\\" ++ show v ++ ". ") <> ppLC 0 e
    |                                                                    ^^
```
